### PR TITLE
Command for forcing a reload of the datastore

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,3 +19,21 @@ Configure CKAN:
 
 * Add to ckan.plugins: nhsengland_skin
 * Change ckan.site_logo to: /images/nhsengland_logo.png
+
+
+Resetting the datastore
+-------------------------
+
+To reset the datastore you can use the force-datastore paster command.
+This command will allow you to force reload on a single resource (if you
+provide its ID), or all resources in the system.
+
+Force all resources to reload into datastore
+
+    paster --plugin=ckanext-nhsengland force-datastore -c /etc/ckan/default/production.ini
+
+Force a single resource to reload into datastore
+
+    paster --plugin=ckanext-nhsengland force-datastore <ID> -c /etc/ckan/default/production.ini
+
+**Note** This command only submits the task to the datapusher.

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        # -*- Extra requirements: -*-
+        "ckanapi==3.3"
     ],
     entry_points='''
         [ckan.plugins]
@@ -29,5 +29,6 @@ setup(
 
         [paste.paster_command]
         zap = ckanext.nhsengland.commands:ZapCommand
+        force-datastore = ckanext.nhsengland.commands:ForceDatastoreCommand
     ''',
 )


### PR DESCRIPTION
The command will allow you to force reload on a single resource (if you
provide its ID), or all resources in the system.

Force all resources

    paster --plugin=ckanext-nhsengland force-datastore -c $CKAN_INI

Force a single resource

    paster --plugin=ckanext-nhsengland force-datastore <ID> -c $CKAN_INI

Note this only submits it for processing to the datapusher, so it won't
necessarily be an immediate update.