### PR TITLE
Create frequencies on startup, not first view.

### DIFF
--- a/ckanext/nhsengland/plugin.py
+++ b/ckanext/nhsengland/plugin.py
@@ -109,6 +109,8 @@ class NHSEnglandPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
         }
 
     def update_config(self, config):
+        create_frequencies()
+
         toolkit.add_template_directory(config, 'templates')
         toolkit.add_public_directory(config, 'public')
         toolkit.add_resource('fanstatic', 'nhsengland')


### PR DESCRIPTION
Frequencies were previously only created the first time a user went to a
page where the frequencies were used (dataset_read or dataset_edit).

This PR instead tries to do it at startup in order to fix #5
